### PR TITLE
Remove stray references to NAT64

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,7 +50,7 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":9080", nil)
 
-	// Install iptables rule to masquerade IPv4 NAT64 traffic
+	// Install iptables rule to handle IPv4 traffic
 	ipt4, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	if err == nil {
 		klog.Infof("Running on IPv4 mode")

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -7,4 +7,4 @@ set -o errexit -o nounset -o pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-docker build . -t aojea/nat64:"${1:-test}"
+docker build . -t aojea/kube-netpol:"${1:-test}"


### PR DESCRIPTION
looks like this was started as a copy of https://github.com/aojea/nat64 but not everything got updated...