### PR TITLE
port to nftables

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 
 	"github.com/aojea/kube-netpol/pkg/networkpolicy"
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sys/unix"
 
@@ -16,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/knftables"
 )
 
 func main() {
@@ -50,45 +50,20 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":9080", nil)
 
-	// Install iptables rule to masquerade IPv4 NAT64 traffic
-	ipt4, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
-	if err == nil {
-		klog.Infof("Running on IPv4 mode")
-		networkPolicyController4 := networkpolicy.NewController(
-			clientset,
-			informersFactory.Networking().V1().NetworkPolicies(),
-			informersFactory.Core().V1().Namespaces(),
-			informersFactory.Core().V1().Pods(),
-			ipt4,
-			104,
-		)
-		go networkPolicyController4.Run(ctx, 5)
-	} else {
-		klog.Infof("Error running on IPv4 mode: %v", err)
-	}
-
-	/* TODO make this configurable, it can be ipv4, ipv6 or dual
-	ipt6, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+	nft, err := knftables.New(knftables.InetFamily, "kube-netpol")
 	if err != nil {
-		log.Fatalf("Could not use iptables IPv6: %v", err)
+		klog.Fatalf("Error initializing nftables: %v", err)
 	}
-	*/
 
-	ipt6, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
-	if err == nil {
-		klog.Infof("Running on IPv6 mode")
-		networkPolicyController6 := networkpolicy.NewController(
-			clientset,
-			informersFactory.Networking().V1().NetworkPolicies(),
-			informersFactory.Core().V1().Namespaces(),
-			informersFactory.Core().V1().Pods(),
-			ipt6,
-			106,
-		)
-		go networkPolicyController6.Run(ctx, 5)
-	} else {
-		klog.Infof("Error running on IPv6 mode: %v", err)
-	}
+	networkPolicyController := networkpolicy.NewController(
+		clientset,
+		informersFactory.Networking().V1().NetworkPolicies(),
+		informersFactory.Core().V1().Namespaces(),
+		informersFactory.Core().V1().Pods(),
+		nft,
+		104,
+	)
+	go networkPolicyController.Run(ctx, 5)
 
 	informersFactory.Start(ctx.Done())
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/aojea/kube-netpol
 go 1.22.0
 
 require (
-	github.com/coreos/go-iptables v0.7.0
 	github.com/florianl/go-nfqueue v1.3.1
 	github.com/mdlayher/netlink v1.6.0
 	github.com/prometheus/client_golang v1.19.0
@@ -14,6 +13,7 @@ require (
 	k8s.io/component-base v0.29.3
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
+	sigs.k8s.io/knftables v0.0.15
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/coreos/go-iptables v0.7.0 h1:XWM3V+MPRr5/q51NuWSgU0fqMad64Zyxs8ZUoMsamr8=
-github.com/coreos/go-iptables v0.7.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -67,6 +65,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
+github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mdlayher/netlink v1.6.0 h1:rOHX5yl7qnlpiVkFWoqccueppMtXzeziFjWAjLg6sz0=
@@ -207,6 +207,8 @@ k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSn
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/knftables v0.0.15 h1:+zYTQ4qBoU0PCvLnnlLTIOKxIdOUY106+3oWT7A7vEE=
+sigs.k8s.io/knftables v0.0.15/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=


### PR DESCRIPTION
Ports from iptables to nftables, plus two bugfixes:
- It no longer uses the "bypass" option to nfqueue, because if we are unable to keep up with packets, we need to drop by default, not accept by default. (This is another reason to eventually scope the netfilter rules to intercept less traffic. In particular, if we know the "cluster CIDR", then we can avoid needing to intercept traffic outside that range. Or more precisely, we could create an nftables `set` containing the IPs of all pods that are subject to NetworkPolicy, and only intercept traffic related to them.)
- We intercept in `input` as well as `forward` and `output`... I was thinking this may be necessary with some network plugins, but actually now I'm not so sure... maybe I should revert that part and we can add it later if needed.

With the nftables `inet` family we can intercept IPv4 and IPv6 packets with a single controller, so now the code doesn't really even need to think about single-stack-ipv4/single-stack-ipv6/dual-stack.

Fixes #1