### PR TITLE
[WIP] Process DNS

### DIFF
--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -3,8 +3,6 @@ package networkpolicy
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"net"
 	"os/exec"
@@ -765,78 +763,4 @@ func (c *Controller) evaluatePorts(networkPolicyPorts []networkingv1.NetworkPoli
 		}
 	}
 	return false
-}
-
-type packet struct {
-	family  v1.IPFamily
-	srcIP   net.IP
-	dstIP   net.IP
-	proto   v1.Protocol
-	srcPort int
-	dstPort int
-	payload []byte
-}
-
-func (p packet) String() string {
-	return fmt.Sprintf("%s:%d %s:%d %s :: %s", p.srcIP.String(), p.srcPort, p.dstIP.String(), p.dstPort, p.proto, hex.Dump(p.payload))
-}
-
-// https://en.wikipedia.org/wiki/Internet_Protocol_version_4#Packet_structure
-// https://en.wikipedia.org/wiki/IPv6_packet
-// https://github.com/golang/net/blob/master/ipv4/header.go
-func parsePacket(b []byte) (packet, error) {
-	t := packet{}
-	if b == nil {
-		return t, fmt.Errorf("empty payload")
-	}
-	version := int(b[0] >> 4)
-	// initialize variables
-	hdrlen := -1
-	protocol := -1
-	switch version {
-	case 4:
-		t.family = v1.IPv4Protocol
-		hdrlen = int(b[0]&0x0f) << 2
-		if len(b) < hdrlen+4 {
-			return t, fmt.Errorf("payload to short, received %d expected at least %d", len(b), hdrlen+4)
-		}
-		t.srcIP = net.IPv4(b[12], b[13], b[14], b[15])
-		t.dstIP = net.IPv4(b[16], b[17], b[18], b[19])
-		protocol = int(b[9])
-	case 6:
-		t.family = v1.IPv6Protocol
-		hdrlen = 40
-		if len(b) < hdrlen+4 {
-			return t, fmt.Errorf("payload to short, received %d expected at least %d", len(b), hdrlen+4)
-		}
-		t.srcIP = make(net.IP, net.IPv6len)
-		copy(t.srcIP, b[8:24])
-		t.dstIP = make(net.IP, net.IPv6len)
-		copy(t.dstIP, b[24:40])
-		// NextHeader (not extension headers supported)
-		protocol = int(b[6])
-	default:
-		return t, fmt.Errorf("unknown versions %d", version)
-	}
-
-	switch protocol {
-	case 6:
-		t.proto = v1.ProtocolTCP
-	case 17:
-		t.proto = v1.ProtocolUDP
-	case 132:
-		t.proto = v1.ProtocolSCTP
-	default:
-		return t, fmt.Errorf("unknown protocol %d", protocol)
-	}
-	// TCP, UDP and SCTP srcPort and dstPort are the first 4 bytes after the IP header
-	t.srcPort = int(binary.BigEndian.Uint16(b[hdrlen : hdrlen+2]))
-	t.dstPort = int(binary.BigEndian.Uint16(b[hdrlen+2 : hdrlen+4]))
-	// Obtain the offset of the payload
-	// TODO allow to filter by the payload
-	dataOffset := int(b[hdrlen+12] >> 4)
-	if len(b) >= hdrlen+dataOffset {
-		t.payload = b[hdrlen+dataOffset:]
-	}
-	return t, nil
 }

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -328,7 +328,7 @@ func (c *Controller) Run(ctx context.Context) error {
 // and check if network policies must apply.
 // TODO: We can divert only the traffic affected by network policies using a set in nftables or an IPset.
 func (c *Controller) syncNFTablesRules(ctx context.Context) {
-	rule := fmt.Sprintf("ct state new queue to %d", c.config.QueueID)
+	rule := fmt.Sprintf("ip protocol { tcp, udp, sctp } ct state new queue to %d", c.config.QueueID)
 	if c.config.FailOpen {
 		rule = rule + " bypass"
 	}

--- a/pkg/networkpolicy/dns.go
+++ b/pkg/networkpolicy/dns.go
@@ -1,0 +1,86 @@
+package networkpolicy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func processDNSPacket(b []byte, wantName string, isTCP bool) {
+	if isTCP {
+		// As per RFC 1035, TCP DNS messages are preceded by a 16 bit size, skip first 2 bytes.
+		b = b[2:]
+	} else {
+		// RFC1035 max 512 bytes for UDP
+		if len(b) > 512 {
+			return
+		}
+
+	}
+
+	var p dnsmessage.Parser
+	_, err := p.Start(b)
+	if err != nil {
+		return
+	}
+
+	for {
+		q, err := p.Question()
+		if err == dnsmessage.ErrSectionDone {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		if q.Name.String() != wantName {
+			continue
+		}
+
+		fmt.Println("Found question for name", wantName)
+		if err := p.SkipAllQuestions(); err != nil {
+			panic(err)
+		}
+		break
+	}
+
+	var gotIPs []net.IP
+	for {
+		h, err := p.AnswerHeader()
+		if err == dnsmessage.ErrSectionDone {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		if (h.Type != dnsmessage.TypeA && h.Type != dnsmessage.TypeAAAA) || h.Class != dnsmessage.ClassINET {
+			continue
+		}
+
+		if !strings.EqualFold(h.Name.String(), wantName) {
+			if err := p.SkipAnswer(); err != nil {
+				panic(err)
+			}
+			continue
+		}
+
+		switch h.Type {
+		case dnsmessage.TypeA:
+			r, err := p.AResource()
+			if err != nil {
+				panic(err)
+			}
+			gotIPs = append(gotIPs, r.A[:])
+		case dnsmessage.TypeAAAA:
+			r, err := p.AAAAResource()
+			if err != nil {
+				panic(err)
+			}
+			gotIPs = append(gotIPs, r.AAAA[:])
+		}
+	}
+
+}

--- a/pkg/networkpolicy/packet.go
+++ b/pkg/networkpolicy/packet.go
@@ -1,0 +1,84 @@
+package networkpolicy
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type packet struct {
+	family  v1.IPFamily
+	srcIP   net.IP
+	dstIP   net.IP
+	proto   v1.Protocol
+	srcPort int
+	dstPort int
+	payload []byte
+}
+
+func (p packet) String() string {
+	return fmt.Sprintf("%s:%d %s:%d %s :: %s", p.srcIP.String(), p.srcPort, p.dstIP.String(), p.dstPort, p.proto, hex.Dump(p.payload))
+}
+
+// https://en.wikipedia.org/wiki/Internet_Protocol_version_4#Packet_structure
+// https://en.wikipedia.org/wiki/IPv6_packet
+// https://github.com/golang/net/blob/master/ipv4/header.go
+func parsePacket(b []byte) (packet, error) {
+	t := packet{}
+	if b == nil {
+		return t, fmt.Errorf("empty payload")
+	}
+	version := int(b[0] >> 4)
+	// initialize variables
+	hdrlen := -1
+	protocol := -1
+	switch version {
+	case 4:
+		t.family = v1.IPv4Protocol
+		hdrlen = int(b[0]&0x0f) << 2
+		if len(b) < hdrlen+4 {
+			return t, fmt.Errorf("payload to short, received %d expected at least %d", len(b), hdrlen+4)
+		}
+		t.srcIP = net.IPv4(b[12], b[13], b[14], b[15])
+		t.dstIP = net.IPv4(b[16], b[17], b[18], b[19])
+		protocol = int(b[9])
+	case 6:
+		t.family = v1.IPv6Protocol
+		hdrlen = 40
+		if len(b) < hdrlen+4 {
+			return t, fmt.Errorf("payload to short, received %d expected at least %d", len(b), hdrlen+4)
+		}
+		t.srcIP = make(net.IP, net.IPv6len)
+		copy(t.srcIP, b[8:24])
+		t.dstIP = make(net.IP, net.IPv6len)
+		copy(t.dstIP, b[24:40])
+		// NextHeader (not extension headers supported)
+		protocol = int(b[6])
+	default:
+		return t, fmt.Errorf("unknown versions %d", version)
+	}
+
+	switch protocol {
+	case 6:
+		t.proto = v1.ProtocolTCP
+	case 17:
+		t.proto = v1.ProtocolUDP
+	case 132:
+		t.proto = v1.ProtocolSCTP
+	default:
+		return t, fmt.Errorf("unknown protocol %d", protocol)
+	}
+	// TCP, UDP and SCTP srcPort and dstPort are the first 4 bytes after the IP header
+	t.srcPort = int(binary.BigEndian.Uint16(b[hdrlen : hdrlen+2]))
+	t.dstPort = int(binary.BigEndian.Uint16(b[hdrlen+2 : hdrlen+4]))
+	// Obtain the offset of the payload
+	// TODO allow to filter by the payload
+	dataOffset := int(b[hdrlen+12] >> 4)
+	if len(b) >= hdrlen+dataOffset {
+		t.payload = b[hdrlen+dataOffset:]
+	}
+	return t, nil
+}

--- a/pkg/networkpolicy/packet.go
+++ b/pkg/networkpolicy/packet.go
@@ -23,6 +23,14 @@ func (p packet) String() string {
 	return fmt.Sprintf("%s:%d %s:%d %s :: %s", p.srcIP.String(), p.srcPort, p.dstIP.String(), p.dstPort, p.proto, hex.Dump(p.payload))
 }
 
+// simply heuristic to detect dns just by checking if  port number is 53
+func (p packet) isDNS() bool {
+	if p.srcPort == 53 || p.dstPort == 53 {
+		return true
+	}
+	return false
+}
+
 // https://en.wikipedia.org/wiki/Internet_Protocol_version_4#Packet_structure
 // https://en.wikipedia.org/wiki/IPv6_packet
 // https://github.com/golang/net/blob/master/ipv4/header.go


### PR DESCRIPTION
This should be relatively easy to implement, there are few things we need to consider about the scalability of the proposal and to not explode the caches entries.

However, I see most implementations use the heuristic of translating DNS records to IP and block on IPs, that has serious scalability problems  and/or race problems specially if you populate this cache from a different resolver. 

Cilium solves the problem by intercepting the DNS records and populating the cache https://github.com/cilium/cilium/blob/79029db115743b9884a06e1acf0067140d8a33fe/pkg/fqdn/doc.go

This require to store the source IP of the request , the destination dnsname and the IPs of the answers.

However, since we are already intercepting, I prefer to use the method used by the products that offer these kind of services `OpenDNS, Norton DNS, Comodo DNS`, OpenDNS is now Cisco Umbrella, and just reply with a record to a well known blackhole IP so no need to store IP addresses. 

It implies we have to generate or rewrite the packets with DNS responses, but with nfqueue is simple ...

or we just drop the dns request and let the app dealing with the dns request timeout